### PR TITLE
added more sizes of thumbnails

### DIFF
--- a/lib/slideshare_api/model/slideshow.rb
+++ b/lib/slideshare_api/model/slideshow.rb
@@ -5,7 +5,8 @@ module SlideshareApi
                     :id, :title, :stripped_title, :description, :status,
                     :created_at, :updated_at,
                     :username, :user_id,
-                    :url, :thumbnail_url, :thumbnail_size, :thumbnail_small_url, :embed,
+                    :url, :thumbnail_url, :thumbnail_size, :embed,
+                    :thumbnail_small_url, :thumbnail_medium_url, :thumbnail_large_url,
                     :language, :format, :type,
                     :is_downloadable, :is_in_contest,
                     :ppt_location,
@@ -42,6 +43,8 @@ module SlideshareApi
         @thumbnail_url = text_from_xml('ThumbnailURL')
         @thumbnail_size = text_from_xml('ThumbnailSize')
         @thumbnail_small_url = text_from_xml('ThumbnailSmallURL')
+        @thumbnail_medium_url = text_from_xml('ThumbnailXLargeURL')
+        @thumbnail_large_url = text_from_xml('ThumbnailXXLargeURL')
         @embed = text_from_xml('Embed')
         @created_at = Time.parse text_from_xml('Created')
         @updated_at = Time.parse text_from_xml('Updated')

--- a/spec/fixtures/slideshow.xml
+++ b/spec/fixtures/slideshow.xml
@@ -13,6 +13,12 @@
   <ThumbnailSmallURL>
     //cdn.slidesharecdn.com/ss_thumbnails/prerequispourappliquerleleanstartupdanslentreprise-140430023146-phpapp02-140501195007-phpapp01-thumbnail-2.jpg?cb=1398991939
   </ThumbnailSmallURL>
+  <ThumbnailXLargeURL>
+    //cdn.slidesharecdn.com/ss_thumbnails/prerequispourappliquerleleanstartupdanslentreprise-140430023146-phpapp02-140501195007-phpapp01-thumbnail-3.jpg?cb=1398991939
+  </ThumbnailXLargeURL>
+  <ThumbnailXXLargeURL>
+    //cdn.slidesharecdn.com/ss_thumbnails/prerequispourappliquerleleanstartupdanslentreprise-140430023146-phpapp02-140501195007-phpapp01-thumbnail-4.jpg?cb=1398991939
+  </ThumbnailXXLargeURL>
   <Embed>
     &lt;iframe src=&quot;https://www.slideshare.net/slideshow/embed_code/34187090&quot; width=&quot;427&quot;
     height=&quot;356&quot; frameborder=&quot;0&quot; marginwidth=&quot;0&quot; marginheight=&quot;0&quot; scrolling=&quot;no&quot;

--- a/spec/model/slideshow_spec.rb
+++ b/spec/model/slideshow_spec.rb
@@ -46,6 +46,8 @@ describe SlideshareApi::Model::Slideshow do
         it { expect(subject.thumbnail_url).to eq slideshow_xml.search('ThumbnailURL').text }
         it { expect(subject.thumbnail_size).to eq slideshow_xml.search('ThumbnailSize').text }
         it { expect(subject.thumbnail_small_url).to eq slideshow_xml.search('ThumbnailSmallURL').text }
+        it { expect(subject.thumbnail_medium_url).to eq slideshow_xml.search('ThumbnailXLargeURL').text }
+        it { expect(subject.thumbnail_large_url).to eq slideshow_xml.search('ThumbnailXXLargeURL').text }
         it { expect(subject.embed).to eq slideshow_xml.search('Embed').text }
         it { expect(subject.created_at).to eq Time.parse slideshow_xml.search('Created').text }
         it { expect(subject.updated_at).to eq Time.parse slideshow_xml.search('Updated').text }


### PR DESCRIPTION
I don't see anything in the slideshare api documentation about these new sizes, but the XML from API response is giving more sizes. I thought would be a good idea to expose them.